### PR TITLE
Fix devcontainer config to use new vscode user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.formatting.blackPath": "/home/vscode/.local/bin/black",
+		"python.formatting.blackPath": "/usr/local/bin/black",
 		"python.formatting.provider": "black",
 		"python.formatting.blackArgs": [
 			"--line-length",
@@ -22,11 +22,11 @@
 		"python.linting.lintOnSave": true,
 		"python.linting.flake8Enabled": true,
 		"editor.formatOnSave": true,
-		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-		"python.linting.pycodestylePath": "/home/vscode/.local/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/home/vscode/.local/bin/pydocstyle",
+		"python.linting.banditPath": "/usr/local/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
 		"python.linting.pylintPath": "/usr/bin/pylint",
 		"terminal.integrated.profiles.linux": {
 			"bash (login)": {
@@ -42,11 +42,11 @@
 		"ms-python.python",
 		"ms-python.vscode-pylance",
 		"marklarah.pre-commit-vscode"
-	]
+	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	//"postCreateCommand": "bash -i -c 'pip3 install --user .[all]'",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	"remoteUser": "vscode"
 }


### PR DESCRIPTION
This PR (will be very similar to the other 4), it helps address this issue: https://github.com/HERMES-SOC/hermes_eea/issues/6

It sets the default user of the devcontainer to be the new `vscode` user that is introduced in this PR (Should be merged after this one is merged): https://github.com/HERMES-SOC/sdc_aws_base_docker_image/pull/23

It also fixes a few path issues that were pointed out in the issue.