### PR TITLE
Add Cruft Configuration and Cruft Auto PR Github action

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,5 +1,5 @@
 {
-    "template": "/home/dbarrous/dbarrous/hermes_instrument",
+    "template": "https://github.com/HERMES-SOC/hermes_instrument.git",
     "commit": "35cde43220942734867e5207ff69464435120c1a",
     "checkout": null,
     "skip": [
@@ -9,7 +9,7 @@
     "context": {
       "cookiecutter": {
         "instr_name": "spani",
-        "_template": "/home/dbarrous/dbarrous/hermes_instrument"
+        "_template": "https://github.com/HERMES-SOC/hermes_instrument.git"
       }
     },
     "directory": null

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,16 +1,11 @@
 {
-    "template": "https://github.com/HERMES-SOC/hermes_instrument.git",
-    "commit": "35cde43220942734867e5207ff69464435120c1a",
-    "checkout": null,
-    "skip": [
-      "README.rst/",
-      "docs",
-      "docs/*"],
-    "context": {
-      "cookiecutter": {
-        "instr_name": "spani",
-        "_template": "https://github.com/HERMES-SOC/hermes_instrument.git"
-      }
-    },
-    "directory": null
+  "template": "https://github.com/HERMES-SOC/hermes_instrument.git",
+  "commit": "2374d640e38b0c3a4931b04f5d8570c9a10300a4",
+  "context": {
+    "cookiecutter": {
+      "instr_name": "spani",
+      "_template": "https://github.com/HERMES-SOC/hermes_instrument.git"
+    }
+  },
+  "directory": null
 }

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,0 +1,16 @@
+{
+    "template": "/home/dbarrous/dbarrous/hermes_instrument",
+    "commit": "35cde43220942734867e5207ff69464435120c1a",
+    "checkout": null,
+    "skip": [
+      "README.rst/",
+      "docs",
+      "docs/*"],
+    "context": {
+      "cookiecutter": {
+        "instr_name": "spani",
+        "_template": "/home/dbarrous/dbarrous/hermes_instrument"
+      }
+    },
+    "directory": null
+}

--- a/.github/workflows/cruft_auto_pr.yml
+++ b/.github/workflows/cruft_auto_pr.yml
@@ -1,0 +1,36 @@
+# This is a scheduled workflow that creates a PR with the latest changes from the template repo utilizing the cruft tool
+
+name: Cruft Automated Pull Requests
+
+# Controls when the workflow will run
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      
+      - name: Install Cruft
+        run: pip install cruft
+        
+      - name: Run Cruft Update
+        run: cruft update -y
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4.2.0
+        with:
+          title: 'Cruft Template Update'
+          body: '<h2>Cruft Automated Changes:</h2><br/><p>This PR was generated automatically by Cruft, an update to the template repo. Please check the additions/deletions before merging (and edit if required).</p>'


### PR DESCRIPTION
This PR relies on this https://github.com/HERMES-SOC/hermes_instrument/pull/23 to be merged first.

This PR adds the cruft configuration file to pick up the correct updates from the `hermes_instrument` repo template.

It also adds the Cruft Auto PR GitHub action which is a scheduled action that automatically generates a PR with the changes in the `hermes_instrument` cookie-cutter template repo.