### PR TITLE
Add schedule runs and on-demand runs to workflows

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
 
@@ -16,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +29,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[dev]
+        pip install pip setuptools wheel --upgrade
+        # Install spacepy without build isolation to avoid issues with numpy
+        pip install numpy
+        pip install spacepy --no-build-isolation
+        python -m pip install -e '.[style]'
     - name: Lint with Black
       run: |
         black --check --diff hermes_spani

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch: # For on demand runs
+  schedule:
+    - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
 
@@ -16,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +29,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[docs]
+        pip install pip setuptools wheel --upgrade
+        # Install spacepy without build isolation to avoid issues with numpy
+        pip install numpy
+        pip install spacepy --no-build-isolation
+        python -m pip install -e '.[docs]'
     - name: Build docs
       working-directory: ./docs
       run: make html

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches:
       - main
+    workflow_dispatch: # For on demand runs
+    schedule:
+      - cron: 0 0 * * * # Scheduled run every day at midnight
 jobs:
   build:
 
@@ -16,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.9, '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version"]
 authors = [{name = "Steven Christe", email="steven.d.christe@nasa.gov"},
            {name = "Damian Barrous Dumme", email="damianbarrous@gmail.com"}]
 license = {file = "LICENSE.rst"}
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 keywords = ["hermes", "nasa mission", "space weather"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -20,8 +20,6 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
## Description:
In our ongoing efforts to maintain the highest quality in our codebase, this PR introduces two significant enhancements to our 

**Scheduled Runs:** Our pipelines will now run daily at midnight. This will keep our pipelines fresh and ensure that any external changes, such as updates to our dependencies, don't cause bugs.

**On-Demand Runs:** Developers can manually trigger the CI/CD process via the GitHub Actions tab if they need immediate verification of the CI/CD pipeline works without pushing a commit or waiting for a daily check.

**Bump to Python 3.9:** Bumps required version of python to 3.9 to match the recent changes in hermes_core. 