### PR TITLE
Fix Devcontainer Python Settings & Pre-commit flake version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,52 +3,70 @@
 {
 	"name": "Ubuntu 20.04 Python 3",
 	// Repo where this image's Dockerfile is maintained: https://github.com/HERMES-SOC/docker-lambda-base
-	"image": "public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
-	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
-	// Set *default* container specific settings.json values on container create.
-	"settings": {
-		"python.pythonPath": "/usr/bin/python3",
-		"python.languageServer": "Pylance",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.formatting.blackPath": "/usr/local/bin/black",
-		"python.formatting.provider": "black",
-		"python.formatting.blackArgs": [
-			"--line-length",
-			"100"
-		],
-		"python.testing.unittestEnabled": false,
-		"python.testing.pytestEnabled": true,
-		"python.linting.lintOnSave": true,
-		"python.linting.flake8Enabled": true,
-		"editor.formatOnSave": true,
-		"python.linting.banditPath": "/usr/local/bin/bandit",
-		"python.linting.flake8Path": "/usr/local/bin/flake8",
-		"python.linting.mypyPath": "/usr/local/bin/mypy",
-		"python.linting.pycodestylePath": "/usr/local/bin/pycodestyle",
-		"python.linting.pydocstylePath": "/usr/local/bin/pydocstyle",
-		"python.linting.pylintPath": "/usr/bin/pylint",
-		"terminal.integrated.defaultProfile.linux": "bash (login)",
-		"terminal.integrated.profiles.linux": {
-			"bash (login)": {
-				"path": "bash"
-			}
-		}
+	"image": "public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	"initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/dev-swsoc-docker-lambda-base:latest",
+	// If you want to run the production version of the container, comment out the image and initializeCommand lines above and uncomment the line below.
+	// "image": "public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	// "initializeCommand": "docker logout public.ecr.aws && docker pull public.ecr.aws/w5r9l1c8/swsoc-docker-lambda-base:latest",
+	"customizations": {
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"python.pythonPath": "/usr/bin/python3",
+				"python.testing.unittestEnabled": false,
+				"python.testing.pytestEnabled": true,
+				"python.languageServer": "Pylance",
+				
+				//PyLint Settings
+				"pylint.enabled": true,
+				"pylint.path": ["/usr/bin/pylint"],
+				"pylint.lintOnChange": true,
+				
+				// Black Settings
+				"python.editor.defaultFormatter": "ms-python.black-formatter",
+    			"python.editor.formatOnSave": true,
+				"black-formatter.path": ["/usr/local/bin/black"],
+				"black-formatter.args": [
+					"--line-length",
+					"100"
+				],
+
+				// Flake8 Settings
+				"flake8.path": ["/usr/local/bin/flake8"],
+				"flake8.lintOnChange": true,
+				
+				// Terminal Settings
+				"terminal.integrated.defaultProfile.linux": "bash (login)",
+				"terminal.integrated.profiles.linux": {
+					"bash (login)": {
+						"path": "bash"
+					}
+				}
+			},
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.pylint",
+				"ms-python.black-formatter",
+				"ms-python.flake8",
+				"marklarah.pre-commit-vscode",
+				"ms-toolsai.jupyter",
+				"ms-toolsai.jupyter-renderers",
+				"ms-toolsai.jupyter-keymap",
+				"jithurjacob.nbpreviewer"
+			],
+		}	
 	},
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"marklarah.pre-commit-vscode",
-		"ms-toolsai.jupyter",
-		"ms-toolsai.jupyter-renderers",
-		"ms-toolsai.jupyter-keymap",
-		"jithurjacob.nbpreviewer"
-	],
+
 	// Mount to a volume if you'd like to persist data to your disk
-	// "mounts": ["source=<add your /path/on/host here>, target=/workspaces/hermes_core, type=bind"],
+	"mounts": [
+		"source=${localEnv:HOME}/.bash_profile,target=/home/vscode/.bashrc,type=bind,consistency=cached"
+	],
+
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
+	
 	// Use 'postCreateCommand' to run commands after the container is created.
 	//"postCreateCommand": "bash -i -c 'pip3 install --user .[all]'",
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,8 @@ repos:
   # E902 - IOError
   # F822: undefined name in __all__
   # F823: local variable name referenced before assignment
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
     hooks:
       - id: flake8
         args: ['--count', '--select', 'E101,E11,E111,E112,E113,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E133,E20,E211,E231,E241,E242,E251,E252,E26,E265,E266,E27,E301,E302,E303,E304,E305,E306,E401,E402,E502,E701,E711,E712,E713,E714,E722,E731,E901,E902,F822,F823,W191,W291,W292,W293,W391,W601,W602,W603,W604,W605,W690']

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,23 +1,24 @@
-# .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+  jobs:
+    pre_build:
+      - wget https://sdc-aws-support.s3.amazonaws.com/cdf-binaries/latest.zip
+      - unzip latest.zip
+      - pip install pip setuptools wheel --upgrade
+      - pip install numpy
+      - pip install spacepy --no-build-isolation
+      - pip install -e .[docs,all]
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: []
-
-# Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - all
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
This PR Fixes the the Devcontainer settings which have been deprecated to favor the newer settings. Also updates the version of flake used in the pre-commit settings file.

Also, update the readthedocs config to match the version on hermes-eea.

Check out issue for reference: https://github.com/HERMES-SOC/hermes_core/issues/109