### PR TITLE
Updates to use Pathlib rather than str or os.path

### DIFF
--- a/hermes_spani/__init__.py
+++ b/hermes_spani/__init__.py
@@ -1,5 +1,5 @@
 # Licensed under Apache License v2 - see LICENSE.rst
-import os.path
+from pathlib import Path
 
 from hermes_core import log
 from hermes_spani.io.file_tools import read_file
@@ -19,7 +19,7 @@ INST_TARGETNAME = "SPANI"
 INST_TO_SHORTNAME = {INST_NAME: INST_SHORTNAME}
 INST_TO_TARGETNAME = {INST_NAME: INST_TARGETNAME}
 
-_package_directory = os.path.dirname(os.path.abspath(__file__))
-_data_directory = os.path.abspath(os.path.join(_package_directory, "data"))
+_package_directory = Path(__file__).parent
+_data_directory = _package_directory / "data"
 
 log.info(f"hermes_spani version: {__version__}")

--- a/hermes_spani/calibration/calibration.py
+++ b/hermes_spani/calibration/calibration.py
@@ -3,7 +3,6 @@ A module for all things calibration.
 """
 
 import random
-import os.path
 from pathlib import Path
 
 import ccsdspy
@@ -31,13 +30,14 @@ def process_file(data_filename: Path) -> list:
 
     Parameters
     ----------
-    data_filename: str
-        Fully specificied filename of an input file
+    data_filename: `pathlib.Path`
+        Fully specificied filename of an input file.
+        The file contents: Traditional binary packets in CCSDS format
 
     Returns
     -------
-    output_filenames: list
-        Fully specificied filenames for the output files.
+    output_filenames: `list[pathlib.Path]`
+        Fully specificied filenames for the output CDF files.
     """
     log.info(f"Processing file {data_filename}.")
     output_files = []
@@ -58,12 +58,12 @@ def calibrate_file(data_filename: Path) -> Path:
 
     Parameters
     ----------
-    data_filename: Path
+    data_filename: `pathlib.Path`
         Fully specificied filename of the input data file.
 
     Returns
     -------
-    output_filename: Path
+    output_filename: `pathlib.Path`
         Fully specificied filename of the output file.
 
     Examples
@@ -136,7 +136,7 @@ def parse_l0_sci_packets(data_filename: Path) -> dict:
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         Fully specificied filename
 
     Returns
@@ -151,11 +151,11 @@ def parse_l0_sci_packets(data_filename: Path) -> dict:
     >>> data = calib.parse_spani_sci_packets(data_filename)  # doctest: +SKIP
     """
     log.info(f"Parsing packets from file:{data_filename}.")
-    data = {}
-    # pkt = ccsdspy.FixedLength.from_file(
-    #    os.path.join(hermes_spani._data_directory, "SPANI_sci_packet_def.csv")
-    # )
-    # data = pkt.load(data_filename)
+
+    pkt = ccsdspy.FixedLength.from_file(
+        Path(hermes_spani._data_directory) / "SPANI_sci_packet_def.csv"
+    )
+    data = pkt.load(data_filename)
     return data
 
 
@@ -167,12 +167,12 @@ def l0_sci_data_to_cdf(data: dict, original_filename: Path) -> Path:
     ----------
     data: dict
         A dictionary of arrays which includes the ccsds header fields
-    original_filename: Path
+    original_filename: `pathlib.Path`
         The Path to the originating file.
 
     Returns
     -------
-    output_filename: Path
+    output_filename: `pathlib.Path`
         Fully specificied filename of cdf file
 
     Examples
@@ -207,13 +207,13 @@ def get_calibration_file(data_filename: Path, time=None) -> Path:
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         Fully specificied filename of the non-calibrated file (data level < 2)
     time: ~astropy.time.Time
 
     Returns
     -------
-    calib_filename: str
+    calib_filename: `pathlib.Path`
         Fully specificied filename for the appropriate calibration file.
 
     Examples
@@ -228,12 +228,12 @@ def read_calibration_file(calib_filename: Path):
 
     Parameters
     ----------
-    calib_filename: str
+    calib_filename: `pathlib.Path`
         Fully specificied filename of the non-calibrated file (data level < 2)
 
     Returns
     -------
-    output_filename: str
+    output_filename: `pathlib.Path`
         Fully specificied filename of the appropriate calibration file.
 
     Examples

--- a/hermes_spani/io/file_tools.py
+++ b/hermes_spani/io/file_tools.py
@@ -2,16 +2,18 @@
 This module provides a generic file reader.
 """
 
+from pathlib import Path
+
 __all__ = ["read_file"]
 
 
-def read_file(data_filename):
+def read_file(data_filename: Path):
     """
     Read a file.
 
     Parameters
     ----------
-    data_filename: str
+    data_filename: `pathlib.Path`
         A file to read.
 
     Returns

--- a/hermes_spani/tests/test_calibration.py
+++ b/hermes_spani/tests/test_calibration.py
@@ -1,5 +1,4 @@
 import pytest
-import os.path
 from pathlib import Path
 
 import hermes_spani.calibration as calib

--- a/hermes_spani/tests/test_file_tools.py
+++ b/hermes_spani/tests/test_file_tools.py
@@ -1,5 +1,6 @@
+from pathlib import Path
 from hermes_spani.io.file_tools import read_file
 
 
 def test_read_file():
-    assert read_file("test_file.cdf") is None
+    assert read_file(Path("test_file.cdf")) is None


### PR DESCRIPTION
This PR updates the HERMES SPANI processing functionality to consistently use pathlib.Path objects for file paths when processing files. Previously these functions used str objects or os.path, which goes against the HERMES best-practices. This PR aligns the functionality of the package with the best practices defined for the mission code development.